### PR TITLE
remove usage of unreleased features of libical

### DIFF
--- a/bench/bench.exs
+++ b/bench/bench.exs
@@ -4,6 +4,11 @@ defmodule Excal.Benchmarks do
     Enum.take(stream, 1000)
   end
 
+  def test_daily_date_with_end do
+    {:ok, stream} = Excal.Recurrence.Stream.new("FREQ=DAILY", ~D[2018-09-09], until: ~D[2030-09-09])
+    Enum.take(stream, 1000)
+  end
+
   def test_daily_datetime do
     {:ok, stream} = Excal.Recurrence.Stream.new("FREQ=DAILY", ~N[2018-09-09 12:30:00])
     Enum.take(stream, 1000)
@@ -30,6 +35,7 @@ alias Excal.Benchmarks
 Benchee.run(
   %{
     "test_daily_date" => fn -> Benchmarks.test_daily_date() end,
+    "test_daily_date_with_end" => fn -> Benchmarks.test_daily_date_with_end() end,
     "test_daily_datetime" => fn -> Benchmarks.test_daily_datetime() end,
     "test_weekly_date" => fn -> Benchmarks.test_weekly_date() end,
     "test_weekly_datetime" => fn -> Benchmarks.test_weekly_datetime() end

--- a/lib/excal/interface/recurrence/iterator.ex
+++ b/lib/excal/interface/recurrence/iterator.ex
@@ -7,6 +7,5 @@ defmodule Excal.Interface.Recurrence.Iterator do
 
   def new(_rrule, _dtstart), do: raise("NIF new/2 not implemented")
   def set_start(_iterator, _start), do: raise("NIF set_start/2 not implemented")
-  # def set_end(_iterator, _end), do: raise("NIF set_end/2 not implemented")
   def next(_iterator), do: raise("NIF next/1 not implemented")
 end

--- a/lib/excal/recurrence/stream.ex
+++ b/lib/excal/recurrence/stream.ex
@@ -25,11 +25,11 @@ defmodule Excal.Recurrence.Stream do
     end
   end
 
-  # defp process_options(iterator, [{:until, time} | rest]) do
-  #   with {:ok, iterator} <- Iterator.set_end(iterator, time) do
-  #     process_options(iterator, rest)
-  #   end
-  # end
+  defp process_options(iterator, [{:until, time} | rest]) do
+    with {:ok, iterator} <- Iterator.set_end(iterator, time) do
+      process_options(iterator, rest)
+    end
+  end
 
   defp make_stream(rrule, dtstart, opts) do
     Elixir.Stream.resource(

--- a/src/recurrence/iterator.c
+++ b/src/recurrence/iterator.c
@@ -195,38 +195,6 @@ recurrence_iterator_set_start(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
   }
 }
 
-// static ERL_NIF_TERM
-// recurrence_iterator_set_end(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
-// {
-//   // get iterator arg
-//   icalrecur_iterator *iterator;
-//   if (argc < 1 || !get_iterator(env, argv[0], &iterator))
-//   {
-//     return enif_make_badarg(env);
-//   }
-
-//   // get end string arg
-//   char *end_string;
-//   if (argc < 2 || !get_string_from_binary(env, argv[1], &end_string))
-//   {
-//     return enif_make_badarg(env);
-//   }
-
-//   // build end from end_string
-//   // TODO: timezones?
-//   struct icaltimetype end = icaltime_from_string(end_string);
-//   if (icaltime_is_null_time(end))
-//   {
-//     return make_error_tuple(env, "invalid_end");
-//   }
-
-//   // set iterator end
-//   icalrecur_iterator_set_end(iterator, end);
-
-//   // return :ok
-//   return enif_make_atom(env, "ok");
-// }
-
 static ERL_NIF_TERM
 recurrence_iterator_next(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -262,7 +230,6 @@ recurrence_iterator_next(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 static ErlNifFunc nif_funcs[] = {
     {"new", 2, recurrence_iterator_new},
     {"set_start", 2, recurrence_iterator_set_start},
-    // {"set_end", 2, recurrence_iterator_set_end},
     {"next", 1, recurrence_iterator_next}};
 
 ERL_NIF_INIT(Elixir.Excal.Interface.Recurrence.Iterator, nif_funcs, &load, NULL, &upgrade, NULL)

--- a/test/excal/interface/recurrence/iterator_test.exs
+++ b/test/excal/interface/recurrence/iterator_test.exs
@@ -49,22 +49,6 @@ defmodule Excal.Interface.Recurrence.IteratorTest do
     end
   end
 
-  # describe "Iterator.set_end/2" do
-  #   setup [:iterator]
-
-  #   test "returns :ok if the end time is valid", %{iterator: iterator} do
-  #     assert :ok = Iterator.set_end(iterator, "20190909")
-  #   end
-
-  #   test "raises ArgumentError when not given a string for end", %{iterator: iterator} do
-  #     assert_raise ArgumentError, fn -> Iterator.set_end(iterator, :invalid) end
-  #   end
-
-  #   test "raises ArgumentError when not given a valid iterator" do
-  #     assert_raise ArgumentError, fn -> Iterator.set_end(:invalid, "20190909") end
-  #   end
-  # end
-
   describe "Iterator.next/1" do
     setup [:iterator]
 
@@ -89,13 +73,6 @@ defmodule Excal.Interface.Recurrence.IteratorTest do
       assert {2019, 9, 9} = Iterator.next(iterator)
     end
 
-    # @tag end: "20180911"
-    # test "respects the given end time", %{iterator: iterator} do
-    #   assert {2018, 9, 9} = Iterator.next(iterator)
-    #   assert {2018, 9, 10} = Iterator.next(iterator)
-    #   assert is_nil(Iterator.next(iterator))
-    # end
-
     test "raises ArgumentError when not given an iterator" do
       assert_raise ArgumentError, fn -> Iterator.next(:invalid) end
     end
@@ -110,10 +87,6 @@ defmodule Excal.Interface.Recurrence.IteratorTest do
     if start_time = Map.get(context, :start) do
       Iterator.set_start(iterator, start_time)
     end
-
-    # if end_time = Map.get(context, :end) do
-    #   Iterator.set_end(iterator, end_time)
-    # end
 
     [iterator: iterator]
   end

--- a/test/excal/recurrence/iterator_test.exs
+++ b/test/excal/recurrence/iterator_test.exs
@@ -34,17 +34,17 @@ defmodule Excal.Recurrence.IteratorTest do
     end
   end
 
-  # describe "Iterator.set_end/2" do
-  #   setup [:iterator]
+  describe "Iterator.set_end/2" do
+    setup [:iterator]
 
-  #   test "returns :ok if the end time is valid", %{iterator: iterator} do
-  #     assert {:ok, %Iterator{}} = Iterator.set_end(iterator, ~D[2019-09-09])
-  #   end
+    test "returns :ok if the end time is valid", %{iterator: iterator} do
+      assert {:ok, %Iterator{}} = Iterator.set_end(iterator, ~D[2019-09-09])
+    end
 
-  #   test "returns an error when the end type doesn't match the iterator's dtstart type", %{iterator: iterator} do
-  #     assert {:error, :datetime_type_mismatch} = Iterator.set_end(iterator, ~N[2018-09-09 12:30:00])
-  #   end
-  # end
+    test "returns an error when the end type doesn't match the iterator's dtstart type", %{iterator: iterator} do
+      assert {:error, :datetime_type_mismatch} = Iterator.set_end(iterator, ~N[2018-09-09 12:30:00])
+    end
+  end
 
   describe "Iterator.next/1" do
     setup [:iterator]
@@ -70,12 +70,12 @@ defmodule Excal.Recurrence.IteratorTest do
       assert {~D[2019-09-09], %Iterator{}} = Iterator.next(iterator)
     end
 
-    # @tag end: ~D[2018-09-11]
-    # test "respects the given end time", %{iterator: iterator} do
-    #   assert {~D[2018-09-09], %Iterator{} = iterator} = Iterator.next(iterator)
-    #   assert {~D[2018-09-10], %Iterator{} = iterator} = Iterator.next(iterator)
-    #   assert {nil, %Iterator{}} = Iterator.next(iterator)
-    # end
+    @tag end: ~D[2018-09-11]
+    test "respects the given end time", %{iterator: iterator} do
+      assert {~D[2018-09-09], %Iterator{} = iterator} = Iterator.next(iterator)
+      assert {~D[2018-09-10], %Iterator{} = iterator} = Iterator.next(iterator)
+      assert {nil, %Iterator{}} = Iterator.next(iterator)
+    end
   end
 
   defp iterator(context) do
@@ -84,7 +84,7 @@ defmodule Excal.Recurrence.IteratorTest do
 
     {:ok, iterator} = Iterator.new(rrule, dtstart)
     iterator = add_start(Map.get(context, :start), iterator)
-    # iterator = add_end(Map.get(context, :end), iterator)
+    iterator = add_end(Map.get(context, :end), iterator)
 
     [iterator: iterator]
   end
@@ -96,10 +96,10 @@ defmodule Excal.Recurrence.IteratorTest do
     iterator
   end
 
-  # defp add_end(nil, iterator), do: iterator
+  defp add_end(nil, iterator), do: iterator
 
-  # defp add_end(end_time, iterator) do
-  #   {:ok, iterator} = Iterator.set_end(iterator, end_time)
-  #   iterator
-  # end
+  defp add_end(end_time, iterator) do
+    {:ok, iterator} = Iterator.set_end(iterator, end_time)
+    iterator
+  end
 end

--- a/test/excal/recurrence/stream_test.exs
+++ b/test/excal/recurrence/stream_test.exs
@@ -28,10 +28,10 @@ defmodule Excal.Recurrence.StreamTest do
       assert is_function(stream)
     end
 
-    # test "accepts an option for end time" do
-    #   assert {:ok, stream} = RecurrenceStream.new("FREQ=DAILY", ~D[2018-09-09], until: ~D[2019-09-09])
-    #   assert is_function(stream)
-    # end
+    test "accepts an option for end time" do
+      assert {:ok, stream} = RecurrenceStream.new("FREQ=DAILY", ~D[2018-09-09], until: ~D[2019-09-09])
+      assert is_function(stream)
+    end
   end
 
   describe "Taking occurrences from the stream" do
@@ -86,18 +86,18 @@ defmodule Excal.Recurrence.StreamTest do
              ]
     end
 
-    # @tag rrule: "FREQ=WEEKLY"
-    # @tag dtstart: ~D[2018-09-09]
-    # @tag until: ~D[2018-09-24]
-    # test "respects the configured end time", %{stream: stream} do
-    #   times = Enum.to_list(stream)
+    @tag rrule: "FREQ=WEEKLY"
+    @tag dtstart: ~D[2018-09-09]
+    @tag until: ~D[2018-09-24]
+    test "respects the configured end time", %{stream: stream} do
+      times = Enum.to_list(stream)
 
-    #   assert times == [
-    #            ~D[2018-09-09],
-    #            ~D[2018-09-16],
-    #            ~D[2018-09-23]
-    #          ]
-    # end
+      assert times == [
+               ~D[2018-09-09],
+               ~D[2018-09-16],
+               ~D[2018-09-23]
+             ]
+    end
   end
 
   defp stream(context) do


### PR DESCRIPTION
Removing the call to `icalrecur_iterator_set_end` allows this to be compiled against versions of libical greater than 3.0.0, and no longer requiring libical master.