### PR TITLE
Improve building and fix NIF path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-$(shell mkdir -p priv/recurrence)
-
 CFLAGS = -O3 -Wall
 
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
@@ -13,8 +11,17 @@ ifneq ($(OS),Windows_NT)
 	endif
 endif
 
-all:
-	$(CC) $(CFLAGS) -shared -o priv/recurrence/iterator.so src/recurrence/iterator.c -lical $(LDFLAGS)
+SOURCE_FILES = src/recurrence/iterator.c
+LIBRARY_DIRECTORY = priv/recurrence
+LIBRARY = $(LIBRARY_DIRECTORY)/iterator.so
+
+all: $(SOURCE_FILES) $(LIBRARY)
+
+$(LIBRARY): $(LIBRARY_DIRECTORY)
+	$(CC) $(CFLAGS) -shared -o $(LIBRARY) $(SOURCE_FILES) -lical $(LDFLAGS)
+
+$(LIBRARY_DIRECTORY):
+	mkdir -p priv/recurrence
 
 clean:
 	rm  -r "priv/recurrence/iterator.so"

--- a/lib/excal/interface/recurrence/iterator.ex
+++ b/lib/excal/interface/recurrence/iterator.ex
@@ -7,7 +7,7 @@ defmodule Excal.Interface.Recurrence.Iterator do
   @type iterator_start_error :: :invalid_start | :start_invalid_for_rule
 
   @doc false
-  def load_nifs, do: :erlang.load_nif('./priv/recurrence/iterator', 0)
+  def load_nifs, do: [:code.priv_dir(:excal), '/recurrence/iterator'] |> :erlang.load_nif(0)
 
   @spec new(String.t(), String.t()) ::
           {:ok, reference()} | {:error, initialization_error()}

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,3 @@
-defmodule Mix.Tasks.Compile.Excal do
-  def run(_args) do
-    {result, _errcode} = System.cmd("make", [])
-    IO.binwrite(result)
-  end
-end
-
 defmodule Excal.MixProject do
   use Mix.Project
 
@@ -14,7 +7,7 @@ defmodule Excal.MixProject do
   def project do
     [
       app: :excal,
-      compilers: [:excal] ++ Mix.compilers(),
+      compilers: [:elixir_make] ++ Mix.compilers(),
       version: @version,
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
@@ -24,7 +17,8 @@ defmodule Excal.MixProject do
       docs: docs(),
       source_url: @source_url,
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test]
+      preferred_cli_env: [coveralls: :test],
+      make_clean: ["clean"]
     ]
   end
 
@@ -71,7 +65,8 @@ defmodule Excal.MixProject do
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.18", only: :dev, runtime: false},
-      {:excoveralls, "~> 0.9", only: :test, runtime: false}
+      {:excoveralls, "~> 0.9", only: :test, runtime: false},
+      {:elixir_make, "~> 0.4", runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.4", "b86230f0978bbc630c139af5066af7cd74fd16536f71bc047d1037091f9f63a9", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
- Use elixir_make for a more robust build process
- Update Makefile to not recompile everytime
- Fix NIF path issue

Re the NIF path, I was getting the following error when trying to use the library as a dependency:

```
  [warn] The on_load function for module Elixir.Excal.Interface.Recurrence.Iterator returned:
{:error, {:load_failed, 'Failed to load NIF library: \'dlopen(./priv/recurrence/iterator.so, 2): image not found\''}}
```